### PR TITLE
feat: expose internal Prometheus metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,10 @@ API_PREFIX=api
 STATIC_PREFIX=static
 CURRENT_SEASON=24
 
+# Internal Prometheus endpoint (do not publish through the public proxy)
+METRICS_HOST=0.0.0.0
+METRICS_PORT=9464
+
 # External Services
 AFTT_WSDL=https://api.aftt.be/?wsdl
 VTLL_WSDL=https://api.aftt.be/?wsdl

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -21,6 +21,11 @@ perform rolling updates for Compose applications. The root
 `docker-compose-prd.yml` is a transitional recovery/rehearsal stack, not the
 target production control plane.
 
+The API, notifications service and importer each expose Prometheus metrics on
+internal port `9464`. This port is reachable only from the host observability
+agent through the private `coolify` Docker network; it must not receive a
+public domain or a host port mapping.
+
 ## Image lifecycle
 
 `.github/workflows/containers.yml` builds all four images from every relevant
@@ -89,6 +94,14 @@ graceful stop window from Coolify.
 
 Do not configure host port mappings such as `3050:3050`; they prevent the old
 and new containers from coexisting during a rolling update.
+
+## Internal metrics
+
+All three runtime applications listen on `METRICS_HOST` and `METRICS_PORT`,
+which default to `0.0.0.0:9464`. The API and notifications service expose HTTP
+request counters and duration histograms in addition to Node.js process
+metrics; the importer exposes Node.js process metrics. See `OBSERVABILITY.md`
+for the Alloy discovery and verification queries.
 
 ## Database and Redis
 

--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -1,0 +1,119 @@
+# Observability
+
+## Production topology
+
+Prometheus, Grafana, Loki and the blackbox exporter run on the central Escape
+Key platform node. Their host ports bind only to its Tailscale address.
+
+Every application VPS runs Grafana Alloy with node-exporter and cAdvisor:
+
+- node-exporter covers host CPU, memory, filesystem and network metrics;
+- cAdvisor covers every running Docker container;
+- Alloy forwards metrics to the central Prometheus remote-write receiver and
+  Docker logs to Loki.
+
+The BePing applications additionally expose Prometheus metrics on internal port
+`9464`:
+
+| Service | Metrics |
+| --- | --- |
+| API | Node.js/process defaults, HTTP request count and duration |
+| Notifications | Node.js/process defaults, HTTP request count and duration |
+| Importer | Node.js/process defaults |
+
+`9464` is not an application or health-check port. Do not add a public Coolify
+domain or host port for it.
+
+## Alloy application discovery
+
+The Alloy service on the BePing VPS must join both its own Compose network and
+the external `coolify` network so that it can reach application containers:
+
+```yaml
+services:
+  alloy:
+    networks:
+      - default
+      - coolify
+
+networks:
+  coolify:
+    external: true
+```
+
+Add this pipeline to the existing Alloy configuration. It discovers only the
+three BePing images and only their exposed metrics port, so HTTP application
+ports are never scraped accidentally.
+
+```alloy
+discovery.relabel "beping_applications" {
+  targets = discovery.docker.local.targets
+
+  rule {
+    source_labels = ["__meta_docker_port_private"]
+    action        = "keep"
+    regex         = "9464"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_image"]
+    action        = "keep"
+    regex         = ".*/beping-(api|notifications|importer):.*"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_image"]
+    regex         = ".*/(beping-(api|notifications|importer)):.*"
+    target_label  = "service"
+    replacement   = "$1"
+  }
+
+  rule {
+    target_label = "host"
+    replacement  = sys.env("ALLOY_HOST")
+  }
+
+  rule {
+    target_label = "environment"
+    replacement  = sys.env("ALLOY_ENVIRONMENT")
+  }
+}
+
+prometheus.scrape "beping_applications" {
+  targets         = discovery.relabel.beping_applications.output
+  job_name        = "beping-applications"
+  metrics_path    = "/metrics"
+  scrape_interval = "15s"
+  scrape_timeout  = "5s"
+  forward_to      = [prometheus.remote_write.central.receiver]
+}
+```
+
+Validate the complete Alloy file before redeploying:
+
+```sh
+alloy validate /etc/alloy/config.alloy
+```
+
+## Verification
+
+After deploying immutable images for all three applications, verify locally
+from the Alloy container and then query central Prometheus:
+
+```promql
+up{host="beping-backend", job="beping-applications"}
+```
+
+The result must contain exactly three healthy targets. Confirm application
+telemetry separately:
+
+```promql
+count by (service) ({host="beping-backend", __name__=~"beping_.+"})
+rate(beping_http_requests_total{host="beping-backend"}[5m])
+histogram_quantile(0.95, sum by (le, service) (
+  rate(beping_http_request_duration_seconds_bucket{host="beping-backend"}[5m])
+))
+```
+
+The metrics listener also exposes `/-/healthy`, but the existing application
+health checks remain authoritative for deployment readiness.

--- a/apps/app-notifications/Dockerfile
+++ b/apps/app-notifications/Dockerfile
@@ -59,7 +59,7 @@ RUN chmod +x ./start.sh
 
 USER nestjs
 
-EXPOSE 3000
+EXPOSE 3000 9464
 
 HEALTHCHECK --interval=15s --timeout=3s --start-period=20s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider "http://127.0.0.1:${PORT:-3000}/health/live" || exit 1

--- a/apps/app-notifications/src/main.ts
+++ b/apps/app-notifications/src/main.ts
@@ -3,13 +3,15 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { ValidationPipe } from '@nestjs/common';
-import { getRedisConnectionOptions } from '@app/common';
+import { getRedisConnectionOptions, ServiceMetrics } from '@app/common';
 
 async function bootstrap() {
   // Create HTTP application for external API access
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bufferLogs: true,
   });
+  const metrics = new ServiceMetrics('beping-notifications');
+  metrics.instrumentHttp(app);
   // Configure Express v5 query parser to support nested objects and arrays
   app.set('query parser', 'extended');
 
@@ -33,6 +35,7 @@ async function bootstrap() {
 
   const port = process.env.PORT || 3000;
   await app.listen(port);
+  await metrics.listen();
 
   console.log(`Notifications service running on port ${port}`);
 }

--- a/apps/data-aftt-importer/Dockerfile
+++ b/apps/data-aftt-importer/Dockerfile
@@ -59,8 +59,9 @@ RUN chmod +x ./start.sh
 
 USER nestjs
 
-# No EXPOSE: this app is a Redis microservice (Transport.REDIS) with no HTTP
-# server, so liveness is checked by process presence rather than an HTTP probe.
+# The business transport remains Redis-only. Port 9464 is the internal
+# Prometheus endpoint and is not routed publicly by Coolify.
+EXPOSE 9464
 HEALTHCHECK --interval=60s --timeout=10s --start-period=10s --retries=3 \
     CMD pgrep node > /dev/null || exit 1
 

--- a/apps/data-aftt-importer/src/main.ts
+++ b/apps/data-aftt-importer/src/main.ts
@@ -1,9 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { DataAFTTImporterModule } from './data-aftt-importer.module';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
-import { getRedisConnectionOptions } from '@app/common';
+import { getRedisConnectionOptions, ServiceMetrics } from '@app/common';
 
 async function bootstrap() {
+  const metrics = new ServiceMetrics('beping-importer');
   const app = await NestFactory.createMicroservice<MicroserviceOptions>(
     DataAFTTImporterModule,
     {
@@ -16,6 +17,7 @@ async function bootstrap() {
 
   app.enableShutdownHooks();
   await app.listen();
+  await metrics.listen();
 }
 
 bootstrap();

--- a/apps/tabt-rest/Dockerfile
+++ b/apps/tabt-rest/Dockerfile
@@ -60,7 +60,7 @@ RUN chmod +x ./start.sh
 
 USER nestjs
 
-EXPOSE 3050
+EXPOSE 3050 9464
 
 HEALTHCHECK --interval=15s --timeout=3s --start-period=20s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider "http://127.0.0.1:${PORT:-3050}/v1/health/live" || exit 1

--- a/apps/tabt-rest/src/main.ts
+++ b/apps/tabt-rest/src/main.ts
@@ -9,12 +9,15 @@ import { ValidationPipe, VersioningType } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PackageService } from './common/package/package.service';
 import { Logger } from 'nestjs-pino';
+import { ServiceMetrics } from '@app/common';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     cors: true,
     bufferLogs: true,
   });
+  const metrics = new ServiceMetrics('beping-api');
+  metrics.instrumentHttp(app);
   // Configure Express v5 query parser to support nested objects and arrays
   app.set('query parser', 'extended');
   app.useLogger(app.get(Logger));
@@ -69,6 +72,7 @@ async function bootstrap() {
 
   app.enableShutdownHooks();
   await app.listen(configService.get('PORT') || 3004);
+  await metrics.listen();
 }
 
 bootstrap();

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -4,3 +4,4 @@ export * from './cache-module-opts.factory';
 export * from './cache/cache.service';
 export * from './posthog/posthog.service';
 export * from './redis/redis-connection';
+export * from './metrics/service-metrics';

--- a/libs/common/src/metrics/service-metrics.spec.ts
+++ b/libs/common/src/metrics/service-metrics.spec.ts
@@ -1,0 +1,131 @@
+import type { INestApplication } from '@nestjs/common';
+import { EventEmitter } from 'node:events';
+import { get } from 'node:http';
+import type { NextFunction, Request, Response } from 'express';
+import { ServiceMetrics } from './service-metrics';
+
+interface HttpResult {
+  body: string;
+  contentType?: string;
+  statusCode?: number;
+}
+
+function request(port: number, path: string): Promise<HttpResult> {
+  return new Promise((resolve, reject) => {
+    get({ host: '127.0.0.1', port, path }, (response) => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => (body += chunk));
+      response.on('end', () =>
+        resolve({
+          body,
+          contentType: response.headers['content-type'],
+          statusCode: response.statusCode,
+        }),
+      );
+    }).on('error', reject);
+  });
+}
+
+describe(ServiceMetrics.name, () => {
+  it('collects default process metrics with a stable service label', async () => {
+    const metrics = new ServiceMetrics('test-service');
+
+    const output = await metrics.registry.metrics();
+
+    expect(output).toContain('beping_process_cpu_user_seconds_total');
+    expect(output).toContain('service="test-service"');
+  });
+
+  it('records low-cardinality HTTP request metrics', async () => {
+    let middleware:
+      | ((request: Request, response: Response, next: NextFunction) => void)
+      | undefined;
+    const app = {
+      use: jest.fn((handler) => {
+        middleware = handler;
+      }),
+    } as unknown as Pick<INestApplication, 'use'>;
+    const metrics = new ServiceMetrics('test-api');
+    const response = Object.assign(new EventEmitter(), { statusCode: 201 });
+    const next = jest.fn();
+
+    metrics.instrumentHttp(app);
+    middleware?.(
+      {
+        baseUrl: '/v1',
+        method: 'POST',
+        route: { path: '/members/:id' },
+      } as Request,
+      response as Response,
+      next,
+    );
+    response.emit('finish');
+
+    const output = await metrics.registry.metrics();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(output).toMatch(
+      /beping_http_requests_total\{[^}]*method="POST"[^}]*route="\/v1\/members\/:id"[^}]*status_code="201"[^}]*\} 1/,
+    );
+  });
+
+  it('uses an unmatched route instead of the raw URL', async () => {
+    let middleware:
+      | ((request: Request, response: Response, next: NextFunction) => void)
+      | undefined;
+    const app = {
+      use: (handler: typeof middleware) => {
+        middleware = handler;
+      },
+    } as unknown as Pick<INestApplication, 'use'>;
+    const metrics = new ServiceMetrics('test-api');
+    const response = Object.assign(new EventEmitter(), { statusCode: 404 });
+
+    metrics.instrumentHttp(app);
+    middleware?.(
+      { method: 'GET', originalUrl: '/unknown/123' } as Request,
+      response as Response,
+      jest.fn(),
+    );
+    response.emit('finish');
+
+    expect(await metrics.registry.metrics()).toContain('route="unmatched"');
+  });
+
+  it('serves health and Prometheus endpoints on the internal listener', async () => {
+    const metrics = new ServiceMetrics('test-service');
+    const address = await metrics.listen(0, '127.0.0.1');
+
+    try {
+      const health = await request(address.port, '/-/healthy');
+      const exposition = await request(address.port, '/metrics');
+      const missing = await request(address.port, '/missing');
+
+      expect(health).toMatchObject({ body: 'OK\n', statusCode: 200 });
+      expect(exposition.statusCode).toBe(200);
+      expect(exposition.contentType).toContain('text/plain');
+      expect(exposition.body).toContain('service="test-service"');
+      expect(missing).toMatchObject({ body: 'Not found\n', statusCode: 404 });
+      await expect(metrics.listen(0, '127.0.0.1')).rejects.toThrow(
+        'already listening',
+      );
+    } finally {
+      await metrics.close();
+    }
+
+    await expect(metrics.close()).resolves.toBeUndefined();
+  });
+
+  it('rejects an invalid configured metrics port', async () => {
+    const previousPort = process.env.METRICS_PORT;
+    process.env.METRICS_PORT = 'invalid';
+    const metrics = new ServiceMetrics('test-service');
+
+    try {
+      await expect(metrics.listen()).rejects.toThrow('METRICS_PORT');
+    } finally {
+      if (previousPort === undefined) delete process.env.METRICS_PORT;
+      else process.env.METRICS_PORT = previousPort;
+    }
+  });
+});

--- a/libs/common/src/metrics/service-metrics.ts
+++ b/libs/common/src/metrics/service-metrics.ts
@@ -1,0 +1,155 @@
+import type { INestApplication } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  collectDefaultMetrics,
+  Counter,
+  Histogram,
+  Registry,
+} from 'prom-client';
+
+const DEFAULT_METRICS_HOST = '0.0.0.0';
+const DEFAULT_METRICS_PORT = 9464;
+
+export interface MetricsServerAddress {
+  host: string;
+  port: number;
+}
+
+export class ServiceMetrics {
+  readonly registry = new Registry();
+
+  private readonly logger = new Logger(ServiceMetrics.name);
+  private readonly requests: Counter<'method' | 'route' | 'status_code'>;
+  private readonly requestDuration: Histogram<
+    'method' | 'route' | 'status_code'
+  >;
+  private server?: Server;
+
+  constructor(readonly serviceName: string) {
+    this.registry.setDefaultLabels({ service: serviceName });
+    collectDefaultMetrics({
+      prefix: 'beping_',
+      register: this.registry,
+    });
+
+    this.requests = new Counter({
+      name: 'beping_http_requests_total',
+      help: 'Total number of completed HTTP requests.',
+      labelNames: ['method', 'route', 'status_code'],
+      registers: [this.registry],
+    });
+    this.requestDuration = new Histogram({
+      name: 'beping_http_request_duration_seconds',
+      help: 'HTTP request duration in seconds.',
+      labelNames: ['method', 'route', 'status_code'],
+      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+      registers: [this.registry],
+    });
+  }
+
+  instrumentHttp(app: Pick<INestApplication, 'use'>): void {
+    app.use((request: Request, response: Response, next: NextFunction) => {
+      const stopTimer = this.requestDuration.startTimer();
+
+      response.once('finish', () => {
+        const labels = {
+          method: request.method,
+          route: this.getRouteLabel(request),
+          status_code: String(response.statusCode),
+        };
+
+        this.requests.inc(labels);
+        stopTimer(labels);
+      });
+
+      next();
+    });
+  }
+
+  async listen(
+    port = this.getConfiguredPort(),
+    host = process.env.METRICS_HOST ?? DEFAULT_METRICS_HOST,
+  ): Promise<MetricsServerAddress> {
+    if (this.server) {
+      throw new Error('Metrics server is already listening.');
+    }
+
+    const server = createServer(async (request, response) => {
+      if (request.method === 'GET' && request.url === '/-/healthy') {
+        response.writeHead(200, {
+          'content-type': 'text/plain; charset=utf-8',
+        });
+        response.end('OK\n');
+        return;
+      }
+
+      if (request.method !== 'GET' || request.url !== '/metrics') {
+        response.writeHead(404, {
+          'content-type': 'text/plain; charset=utf-8',
+        });
+        response.end('Not found\n');
+        return;
+      }
+
+      try {
+        response.writeHead(200, { 'content-type': this.registry.contentType });
+        response.end(await this.registry.metrics());
+      } catch (error) {
+        this.logger.error('Unable to render Prometheus metrics.', error);
+        response.writeHead(500, {
+          'content-type': 'text/plain; charset=utf-8',
+        });
+        response.end('Metrics unavailable\n');
+      }
+    });
+
+    this.server = server;
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(port, host, () => {
+          server.off('error', reject);
+          resolve();
+        });
+      });
+    } catch (error) {
+      this.server = undefined;
+      throw error;
+    }
+
+    const address = server.address() as AddressInfo;
+    this.logger.log(
+      `Prometheus metrics for ${this.serviceName} listening on ${host}:${address.port}`,
+    );
+    return { host, port: address.port };
+  }
+
+  async close(): Promise<void> {
+    const server = this.server;
+    if (!server) return;
+
+    this.server = undefined;
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+
+  private getConfiguredPort(): number {
+    const port = Number(process.env.METRICS_PORT ?? DEFAULT_METRICS_PORT);
+    if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+      throw new Error('METRICS_PORT must be an integer between 1 and 65535.');
+    }
+    return port;
+  }
+
+  private getRouteLabel(request: Request): string {
+    const route = request.route as { path?: unknown } | undefined;
+    if (typeof route?.path !== 'string') return 'unmatched';
+
+    return `${request.baseUrl ?? ''}${route.path}` || '/';
+  }
+}

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "pino-multi-stream": "6.0.0",
     "pino-pretty": "13.1.3",
     "posthog-node": "^5.39.4",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "0.2.2",
     "response-time": "2.3.4",
     "rimraf": "6.1.3",
@@ -172,7 +173,8 @@
       "text-summary"
     ],
     "roots": [
-      "<rootDir>/apps/"
+      "<rootDir>/apps/",
+      "<rootDir>/libs/"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       posthog-node:
         specifier: ^5.39.4
         version: 5.39.4(rxjs@7.8.2)
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       reflect-metadata:
         specifier: 0.2.2
         version: 0.2.2
@@ -2144,6 +2147,9 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -4111,6 +4117,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
@@ -4542,6 +4552,9 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   teeny-request@10.1.3:
     resolution: {integrity: sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==}
@@ -6182,8 +6195,7 @@ snapshots:
   '@nodable/entities@2.2.0':
     optional: true
 
-  '@opentelemetry/api@1.9.1':
-    optional: true
+  '@opentelemetry/api@1.9.1': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -7044,6 +7056,8 @@ snapshots:
       require-from-string: 2.0.2
 
   bignumber.js@9.3.1: {}
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -9288,6 +9302,11 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -9745,6 +9764,10 @@ snapshots:
       '@pkgr/core': 0.3.6
 
   tapable@2.3.3: {}
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   teeny-request@10.1.3:
     dependencies:


### PR DESCRIPTION
## Summary
- expose private Prometheus listeners on port 9464 for API, notifications and importer
- record low-cardinality HTTP request counts and latency histograms
- add process/runtime metrics, tests and operational documentation

## Validation
- pnpm lint
- pnpm typecheck
- pnpm exec jest --runInBand (40 suites, 194 tests)
- Nest builds for all three applications

The metrics port remains internal and is not routed through Coolify or a public host port.