### PR TITLE
fix(ci): update QEMU binfmt and add build timeouts for arm64 builds

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -52,6 +52,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Recent QEMU: node under emulated arm64 SIGILLs with the runner's
+      # stock binfmt (pnpm install then hangs forever).
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          image: tonistiigi/binfmt:latest
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,6 +45,7 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -64,6 +65,13 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
+
+      # Recent QEMU: node under emulated arm64 SIGILLs with the runner's
+      # stock binfmt (pnpm install then hangs forever, see run 30735188672).
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:latest
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -112,9 +120,15 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:latest
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Problem

[Run 30735188672](https://github.com/BePing/beping-backends/actions/runs/30735188672) — `build-and-push (data-aftt-importer)` hung 3h08m before manual cancel (attempt 2, same failure both times):

```
#36 [linux/arm64 prod-deps 6/6] RUN pnpm install --prod --frozen-lockfile
#36 39.73 qemu: uncaught target signal 4 (Illegal instruction) - core dumped
```

Node 26.5.0 under the runner's stock qemu-user emulation SIGILLs on the `linux/arm64` leg; pnpm then waits on the dead child forever. No `timeout-minutes` on the job → GitHub's 6h default. The failed matrix leg also skipped `deploy-production`, blocking the release.

## Fix

1. **`docker/setup-qemu-action` with `tonistiigi/binfmt:latest`** before Buildx in `release-please.yml` (both build jobs) and `containers.yml` — recent QEMU fixes the known Node/V8 SIGILL under emulation.
2. **`timeout-minutes: 30`** on `build-and-push` and `build-and-push-migrate` in `release-please.yml` (`containers.yml` already had 35) — a hang now fails fast.

## Verification

Merge, then re-run the failed jobs of run 30735188672 (or wait for the next release) and confirm the arm64 `pnpm install` step completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)