### PR TITLE
fix(ci): sync required API production secrets

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -40,6 +40,10 @@ jobs:
       DIRECT_URL: ${{ format('postgresql://beping:{0}@{1}:5432/beping', secrets.BEPING_PG18_PASSWORD, vars.COOLIFY_BEPING_POSTGRES18_UUID) }}
       REDIS_URL: ${{ format('redis://default:{0}@{1}:6379/0', secrets.BEPING_REDIS8_PASSWORD, vars.COOLIFY_BEPING_REDIS8_UUID) }}
       FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY_ROTATION }}
+      CAPTAIN_JWT_SECRET: ${{ secrets.CAPTAIN_JWT_SECRET }}
+      CAPTAIN_JWT_REFRESH_SECRET: ${{ secrets.CAPTAIN_JWT_REFRESH_SECRET }}
+      PUBLIC_BASE_URL: ${{ vars.PUBLIC_BASE_URL }}
+      REVENUECAT_SECRET_API_KEY: ${{ secrets.REVENUECAT_SECRET_API_KEY }}
 
     steps:
       - name: Checkout deployment tooling
@@ -65,6 +69,10 @@ jobs:
           test -n "${DIRECT_URL}"
           test -n "${REDIS_URL}"
           test -n "${FIREBASE_PRIVATE_KEY}"
+          test -n "${CAPTAIN_JWT_SECRET}"
+          test -n "${CAPTAIN_JWT_REFRESH_SECRET}"
+          test -n "${PUBLIC_BASE_URL}"
+          test -n "${REVENUECAT_SECRET_API_KEY}"
           test -n "${API_UUID}"
           test -n "${NOTIFICATIONS_UUID}"
           test -n "${IMPORTER_UUID}"
@@ -163,6 +171,26 @@ jobs:
 
           sync_common_envs "${API_UUID}"
           sync_common_envs "${IMPORTER_UUID}"
+
+          jq -n \
+            --arg captain_jwt_secret "${CAPTAIN_JWT_SECRET}" \
+            --arg captain_jwt_refresh_secret "${CAPTAIN_JWT_REFRESH_SECRET}" \
+            --arg public_base_url "${PUBLIC_BASE_URL}" \
+            --arg revenuecat_secret_api_key "${REVENUECAT_SECRET_API_KEY}" \
+            '{
+              data: [
+                {key: "CAPTAIN_JWT_SECRET", value: $captain_jwt_secret, is_literal: true, is_runtime: true, is_buildtime: false},
+                {key: "CAPTAIN_JWT_REFRESH_SECRET", value: $captain_jwt_refresh_secret, is_literal: true, is_runtime: true, is_buildtime: false},
+                {key: "PUBLIC_BASE_URL", value: $public_base_url, is_literal: true, is_runtime: true, is_buildtime: false},
+                {key: "REVENUECAT_SECRET_API_KEY", value: $revenuecat_secret_api_key, is_literal: true, is_runtime: true, is_buildtime: false}
+              ]
+            }' | curl --fail-with-body --silent --show-error \
+              --output /dev/null \
+              -X PATCH \
+              -H "Authorization: Bearer ${COOLIFY_TOKEN}" \
+              -H "Content-Type: application/json" \
+              --data-binary @- \
+              "${COOLIFY_URL%/}/api/v1/applications/${API_UUID}/envs/bulk"
 
           jq -n \
             --arg database_url "${DATABASE_URL}" \


### PR DESCRIPTION
## What changed

- expose the Captain JWT secrets, public API base URL, and RevenueCat server key to the production deployment job
- fail configuration validation before touching production when one is missing
- synchronize the four required values into the Coolify API application

## Root cause

The production API image now validates these settings at startup, but the deployment workflow only synchronized database and Redis configuration. Coolify therefore marked the replacement container unhealthy and rolled back.

## Validation

- workflow YAML parses successfully
- `git diff --check` passes
- the two Captain JWT secrets and `PUBLIC_BASE_URL` have been configured in the GitHub Production environment

`REVENUECAT_SECRET_API_KEY` still needs to be added before merging and redeploying.