### PR TITLE
feat(observability): capture backend usage in PostHog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,11 @@ TRUST_PROXY_HOPS=1
 METRICS_HOST=0.0.0.0
 METRICS_PORT=9464
 
+# PostHog product analytics + error tracking (same BePing project as mobile,
+# shared by API, notifications and importer for end-to-end correlation)
+POSTHOG_API_KEY=phc_your_shared_beping_project_token
+POSTHOG_HOST=https://t.beping.be
+
 # Internal Prometheus endpoint (do not publish through the public proxy)
 METRICS_HOST=0.0.0.0
 METRICS_PORT=9464

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# TabT-Rest 
+# TabT-Rest
+
 ![Coverage:branches](./.badges/badge-branches.svg)
 ![Coverage:functions](./.badges/badge-functions.svg)
 ![Coverage:lines](./.badges/badge-lines.svg)
@@ -21,6 +22,13 @@ $ pnpm install
 ```
 
 Create your own environment file (`.env`) from the `.env.example`
+
+PostHog is optional in production (the services remain safe no-ops without a
+token) and required in development so missing instrumentation is visible:
+
+- `POSTHOG_API_KEY`: BePing project token shared with the mobile app
+- `POSTHOG_HOST`: `https://t.beping.be` (BePing reverse proxy; defaults to this
+  value when omitted). Use `https://eu.i.posthog.com` only as a direct fallback.
 
 ## Running the app
 
@@ -47,6 +55,7 @@ $ pnpm run test:e2e
 # test coverage
 $ pnpm run test:coverage
 ```
+
 ### Start with pm2
 
 ```sh
@@ -55,16 +64,16 @@ pm2 start tabt-rest-pm2.json
 
 ## Release History
 
-* 1.0.0
-    * First complete implementation with OpenApi specs.
-* 1.0.1
-    * OpenApi operationId.
-* 1.0.2
-    * Bug fixes 
-* 1.0.3
-    * Align with Tabt 0.7.24
-* 1.0.4
-    * Disable automatic conversation for DTOs
+- 1.0.0
+  - First complete implementation with OpenApi specs.
+- 1.0.1
+  - OpenApi operationId.
+- 1.0.2
+  - Bug fixes
+- 1.0.3
+  - Align with Tabt 0.7.24
+- 1.0.4
+  - Disable automatic conversation for DTOs
 
 ## Meta
 

--- a/apps/app-notifications/src/app.module.ts
+++ b/apps/app-notifications/src/app.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { APP_FILTER } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ConfigModule } from '@nestjs/config';
 import { LoggerModule } from 'nestjs-pino';
@@ -11,6 +11,7 @@ import { NotificationsModule } from './notifications/notifications.module';
 import { NotificationsController } from './controllers/notifications.controller';
 import { EventsController } from './controllers/events.controller';
 import { AllExceptionsFilter } from './common/filter/all-exceptions.filter';
+import { PostHogRequestInterceptor, PostHogService } from '@app/common';
 
 @Module({
   imports: [
@@ -31,6 +32,12 @@ import { AllExceptionsFilter } from './common/filter/all-exceptions.filter';
     {
       provide: APP_FILTER,
       useClass: AllExceptionsFilter,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useFactory: (posthog: PostHogService) =>
+        new PostHogRequestInterceptor(posthog, 'app-notifications'),
+      inject: [PostHogService],
     },
   ],
 })

--- a/apps/app-notifications/src/common/filter/all-exceptions.filter.ts
+++ b/apps/app-notifications/src/common/filter/all-exceptions.filter.ts
@@ -1,6 +1,10 @@
 import { ArgumentsHost, Catch, HttpException } from '@nestjs/common';
 import { BaseExceptionFilter } from '@nestjs/core';
-import { PostHogService } from '@app/common';
+import {
+  getPostHogRequestContext,
+  PostHogHttpRequest,
+  PostHogService,
+} from '@app/common';
 
 /**
  * Global catch-all filter. Reports server-side failures (HTTP status >= 500
@@ -18,8 +22,11 @@ export class AllExceptionsFilter extends BaseExceptionFilter {
       exception instanceof HttpException ? exception.getStatus() : 500;
 
     if (status >= 500) {
-      this.posthog.captureException(exception, undefined, {
-        source: 'app-notifications',
+      const request = host.switchToHttp().getRequest<PostHogHttpRequest>();
+      const context = getPostHogRequestContext(request, 'app-notifications');
+      this.posthog.captureException(exception, context.distinctId, {
+        ...context.properties,
+        status_code: status,
       });
     }
 

--- a/apps/data-aftt-importer/src/aftt-data-members-list/members-list-sync-processor.ts
+++ b/apps/data-aftt-importer/src/aftt-data-members-list/members-list-sync-processor.ts
@@ -1,7 +1,12 @@
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { Logger } from '@nestjs/common';
-import { PlayerCategory, ImportType, estimateLetterRanking } from '@app/common';
+import {
+  PlayerCategory,
+  ImportType,
+  estimateLetterRanking,
+  PostHogService,
+} from '@app/common';
 import { OnWorkerEvent, Processor, WorkerHost } from '@nestjs/bullmq';
 import { PrismaService } from '@app/common';
 import { Job } from 'bullmq';
@@ -28,6 +33,7 @@ export class MembersListProcessingService extends WorkerHost {
     private readonly cacheService: CacheService,
     private readonly importExecutionCoordinatorService: ImportExecutionCoordinatorService,
     private readonly postgresCopyService: PostgresCopyService,
+    private readonly posthog: PostHogService,
   ) {
     super();
   }
@@ -80,6 +86,13 @@ export class MembersListProcessingService extends WorkerHost {
               { linesAdded: 0, linesUpdated: 0 },
             );
             importRun.finish('skipped');
+            this.posthog.capture('import_run_completed', 'data-aftt-importer', {
+              source: 'data-aftt-importer',
+              import_type: 'members',
+              player_category: String(playerCategory),
+              outcome: 'skipped',
+              duration_ms: Date.now() - startTime,
+            });
             return;
           }
 
@@ -137,12 +150,27 @@ export class MembersListProcessingService extends WorkerHost {
           importRun.record('points_stored', importStats.pointStats.stored);
           importRun.record('points_skipped', importStats.pointStats.skipped);
           importRun.finish('success');
+          this.posthog.capture('import_run_completed', 'data-aftt-importer', {
+            source: 'data-aftt-importer',
+            import_type: 'members',
+            player_category: String(playerCategory),
+            outcome: 'success',
+            duration_ms: totalTime,
+            processed_records: linesProcessed,
+            affected_records: importStats.memberStats.affected,
+          });
 
           this.logger.log(
             `Import completed in ${Math.round(totalTime / 1000)}s (download: ${Date.now() - downloadStart}ms, merge: ${Date.now() - upsertStart}ms)`,
           );
         } catch (e) {
           importRun.finish('failed');
+          this.posthog.captureException(e, 'data-aftt-importer', {
+            source: 'data-aftt-importer',
+            import_type: 'members',
+            player_category: String(playerCategory),
+            duration_ms: Date.now() - startTime,
+          });
           this.logger.error('Failed to finish job', e.message);
           throw e;
         }

--- a/apps/data-aftt-importer/src/aftt-data-results-list/results-processor.service.ts
+++ b/apps/data-aftt-importer/src/aftt-data-results-list/results-processor.service.ts
@@ -1,7 +1,7 @@
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { Logger } from '@nestjs/common';
-import { ImportType, PlayerCategory } from '@app/common';
+import { ImportType, PlayerCategory, PostHogService } from '@app/common';
 import { OnWorkerEvent, Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 import { PrismaService } from '@app/common';
@@ -44,6 +44,7 @@ export class ResultsProcessorService extends WorkerHost {
     private readonly importExecutionCoordinatorService: ImportExecutionCoordinatorService,
     private readonly postgresCopyService: PostgresCopyService,
     private readonly importThrottleService: ImportThrottleService,
+    private readonly posthog: PostHogService,
   ) {
     super();
   }
@@ -94,6 +95,11 @@ export class ResultsProcessorService extends WorkerHost {
               { linesAdded: 0, linesUpdated: 0 },
             );
             importRun.finish('skipped');
+            this.captureImportOutcome(
+              job.data.playerCategory,
+              'skipped',
+              getElapsedMs(),
+            );
             return;
           }
 
@@ -110,6 +116,11 @@ export class ResultsProcessorService extends WorkerHost {
               { linesAdded: 0, linesUpdated: 0 },
             );
             importRun.finish('skipped');
+            this.captureImportOutcome(
+              job.data.playerCategory,
+              'skipped',
+              getElapsedMs(),
+            );
             return;
           }
 
@@ -164,17 +175,50 @@ export class ResultsProcessorService extends WorkerHost {
           importRun.record('updated', mergeStats.linesUpdated);
           importRun.record('dropped', mergeStats.dropped);
           importRun.finish('success');
+          this.captureImportOutcome(
+            job.data.playerCategory,
+            'success',
+            processingTimeMs,
+            {
+              processed_records: dataLines.length,
+              inserted_records: mergeStats.linesAdded,
+              updated_records: mergeStats.linesUpdated,
+              dropped_records: mergeStats.dropped,
+            },
+          );
 
           this.logger.log(
             `Results processing completed. Processed ${dataLines.length} lines in ${processingTimeMs}ms`,
           );
         } catch (e) {
           importRun.finish('failed');
+          this.posthog.captureException(e, 'data-aftt-importer', {
+            source: 'data-aftt-importer',
+            import_type: 'results',
+            player_category: String(job.data.playerCategory),
+            duration_ms: Date.now() - processingStartTime,
+          });
           this.logger.error('Failed to finish results job', e);
           throw e;
         }
       },
     );
+  }
+
+  private captureImportOutcome(
+    playerCategory: PlayerCategory,
+    outcome: 'success' | 'skipped',
+    durationMs: number,
+    properties: Record<string, unknown> = {},
+  ): void {
+    this.posthog.capture('import_run_completed', 'data-aftt-importer', {
+      source: 'data-aftt-importer',
+      import_type: 'results',
+      player_category: String(playerCategory),
+      outcome,
+      duration_ms: durationMs,
+      ...properties,
+    });
   }
 
   // ============================================================================

--- a/apps/data-aftt-importer/src/common.module.ts
+++ b/apps/data-aftt-importer/src/common.module.ts
@@ -8,6 +8,7 @@ import {
   CacheModuleOptsFactory,
   CacheService,
   getRedisConnectionOptions,
+  PostHogService,
   PrismaService,
 } from '@app/common';
 import { ImportExecutionCoordinatorService } from './common/import-execution-coordinator.service';
@@ -76,6 +77,7 @@ import { ImportThrottleService } from './common/import-throttle.service';
     ImportQueueStatusService,
     PostgresCopyService,
     ImportThrottleService,
+    PostHogService,
   ],
   exports: [
     BullModule,
@@ -87,6 +89,7 @@ import { ImportThrottleService } from './common/import-throttle.service';
     ImportQueueStatusService,
     PostgresCopyService,
     ImportThrottleService,
+    PostHogService,
   ],
 })
 export class CommonModule {}

--- a/apps/tabt-rest/src/app.module.ts
+++ b/apps/tabt-rest/src/app.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { APP_FILTER, APP_GUARD } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { ServicesModule } from './services/services.module';
 import { CommonModule } from './common/common.module';
@@ -8,6 +8,7 @@ import { CaptainModule } from './captain/captain.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AllExceptionsFilter } from './common/filter/all-exceptions.filter';
 import { validateApiEnvironment } from './configuration';
+import { PostHogRequestInterceptor, PostHogService } from '@app/common';
 
 @Module({
   imports: [
@@ -40,6 +41,12 @@ import { validateApiEnvironment } from './configuration';
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useFactory: (posthog: PostHogService) =>
+        new PostHogRequestInterceptor(posthog, 'tabt-rest'),
+      inject: [PostHogService],
     },
   ],
 })

--- a/apps/tabt-rest/src/common/filter/all-exceptions.filter.spec.ts
+++ b/apps/tabt-rest/src/common/filter/all-exceptions.filter.spec.ts
@@ -26,7 +26,18 @@ describe('AllExceptionsFilter', () => {
     jest.restoreAllMocks();
   });
 
-  const host = {} as ArgumentsHost;
+  const request = {
+    headers: {
+      'x-posthog-distinct-id': 'mobile-user-1',
+      'x-posthog-session-id': 'session-1',
+    },
+    method: 'GET',
+    path: '/v1/members/42',
+    route: { path: '/v1/members/:id' },
+  };
+  const host = {
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ArgumentsHost;
 
   it('reports 500 HttpExceptions to PostHog and delegates', () => {
     const exception = new HttpException('boom', 500);
@@ -36,9 +47,13 @@ describe('AllExceptionsFilter', () => {
     expect(posthog.captureException).toHaveBeenCalledTimes(1);
     expect(posthog.captureException).toHaveBeenCalledWith(
       exception,
-      undefined,
+      'mobile-user-1',
       {
         source: 'tabt-rest',
+        request_method: 'GET',
+        request_route: '/v1/members/:id',
+        $session_id: 'session-1',
+        status_code: 500,
       },
     );
     expect(superCatch).toHaveBeenCalledWith(exception, host);
@@ -52,9 +67,13 @@ describe('AllExceptionsFilter', () => {
     expect(posthog.captureException).toHaveBeenCalledTimes(1);
     expect(posthog.captureException).toHaveBeenCalledWith(
       exception,
-      undefined,
+      'mobile-user-1',
       {
         source: 'tabt-rest',
+        request_method: 'GET',
+        request_route: '/v1/members/:id',
+        $session_id: 'session-1',
+        status_code: 500,
       },
     );
     expect(superCatch).toHaveBeenCalledWith(exception, host);

--- a/apps/tabt-rest/src/common/filter/all-exceptions.filter.ts
+++ b/apps/tabt-rest/src/common/filter/all-exceptions.filter.ts
@@ -1,6 +1,10 @@
 import { ArgumentsHost, Catch, HttpException } from '@nestjs/common';
 import { BaseExceptionFilter } from '@nestjs/core';
-import { PostHogService } from '@app/common';
+import {
+  getPostHogRequestContext,
+  PostHogHttpRequest,
+  PostHogService,
+} from '@app/common';
 
 /**
  * Global catch-all filter. Reports server-side failures (HTTP status >= 500
@@ -18,8 +22,11 @@ export class AllExceptionsFilter extends BaseExceptionFilter {
       exception instanceof HttpException ? exception.getStatus() : 500;
 
     if (status >= 500) {
-      this.posthog.captureException(exception, undefined, {
-        source: 'tabt-rest',
+      const request = host.switchToHttp().getRequest<PostHogHttpRequest>();
+      const context = getPostHogRequestContext(request, 'tabt-rest');
+      this.posthog.captureException(exception, context.distinctId, {
+        ...context.properties,
+        status_code: status,
       });
     }
 

--- a/apps/tabt-rest/src/common/posthog.service.spec.ts
+++ b/apps/tabt-rest/src/common/posthog.service.spec.ts
@@ -4,6 +4,7 @@ import { PostHogService } from '@app/common';
 jest.mock('posthog-node', () => {
   return {
     PostHog: jest.fn().mockImplementation(() => ({
+      capture: jest.fn(),
       captureException: jest.fn(),
       shutdown: jest.fn().mockResolvedValue(undefined),
     })),
@@ -39,6 +40,13 @@ describe('PostHogService', () => {
       ).not.toThrow();
     });
 
+    it('capture is a safe no-op', () => {
+      const service = new PostHogService();
+      expect(() =>
+        service.capture('api_request_completed', 'user-1'),
+      ).not.toThrow();
+    });
+
     it('onApplicationShutdown resolves without a client', async () => {
       const service = new PostHogService();
       await expect(service.onApplicationShutdown()).resolves.toBeUndefined();
@@ -50,7 +58,7 @@ describe('PostHogService', () => {
       process.env.POSTHOG_API_KEY = 'phc_test';
       new PostHogService();
       expect(PostHogMock).toHaveBeenCalledWith('phc_test', {
-        host: 'https://eu.i.posthog.com',
+        host: 'https://t.beping.be',
       });
     });
 
@@ -72,8 +80,44 @@ describe('PostHogService', () => {
       service.captureException(error, 'user-1', { source: 'test' });
 
       expect(client.captureException).toHaveBeenCalledWith(error, 'user-1', {
+        $process_person_profile: false,
         source: 'test',
       });
+    });
+
+    it('captures product events without creating person profiles', () => {
+      process.env.POSTHOG_API_KEY = 'phc_test';
+      const service = new PostHogService();
+      const client = PostHogMock.mock.results[0].value;
+
+      service.capture('api_request_completed', 'user-1', { status_code: 200 });
+
+      expect(client.capture).toHaveBeenCalledWith({
+        event: 'api_request_completed',
+        distinctId: 'user-1',
+        properties: {
+          $process_person_profile: false,
+          status_code: 200,
+        },
+      });
+    });
+
+    it('uses a stable anonymous id when exception context has no id', () => {
+      process.env.POSTHOG_API_KEY = 'phc_test';
+      const service = new PostHogService();
+      const client = PostHogMock.mock.results[0].value;
+      const error = new Error('boom');
+
+      service.captureException(error, undefined, { source: 'tabt-rest' });
+
+      expect(client.captureException).toHaveBeenCalledWith(
+        error,
+        'tabt-rest:anonymous',
+        {
+          $process_person_profile: false,
+          source: 'tabt-rest',
+        },
+      );
     });
 
     it('swallows client errors in captureException', () => {
@@ -96,5 +140,12 @@ describe('PostHogService', () => {
 
       expect(client.shutdown).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('fails loudly in development when POSTHOG_API_KEY is missing', () => {
+    process.env.NODE_ENV = 'development';
+    expect(() => new PostHogService()).toThrow(
+      'POSTHOG_API_KEY variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once POSTHOG_API_KEY is configured',
+    );
   });
 });

--- a/deploy/coolify/README.md
+++ b/deploy/coolify/README.md
@@ -46,6 +46,13 @@ For API and notifications:
 - configure only `Ports Exposes`, never a host port mapping;
 - use registry pull credentials scoped to the Escape Key namespace.
 
+Set the same `POSTHOG_API_KEY` and `POSTHOG_HOST=https://t.beping.be` on
+API, Notifications and Importer. Sharing the BePing project with the mobile
+app keeps sessions, requests, exceptions and import telemetry correlated on
+the same observability dashboard.
+The direct `https://eu.i.posthog.com` host remains an explicit fallback if the
+reverse proxy must be bypassed during diagnostics.
+
 For the importer, disable auto-deploy. Production promotion updates it only
 after the schema and public applications are healthy.
 

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -3,6 +3,7 @@ export * from './prisma.service';
 export * from './cache-module-opts.factory';
 export * from './cache/cache.service';
 export * from './posthog/posthog.service';
+export * from './posthog/posthog-request.interceptor';
 export * from './redis/redis-connection';
 export * from './metrics/service-metrics';
 export * from './ranking-estimation.constants';

--- a/libs/common/src/posthog/posthog-request.interceptor.spec.ts
+++ b/libs/common/src/posthog/posthog-request.interceptor.spec.ts
@@ -1,0 +1,114 @@
+import { CallHandler, ExecutionContext, HttpException } from '@nestjs/common';
+import { lastValueFrom, of, throwError } from 'rxjs';
+import {
+  getPostHogRequestContext,
+  PostHogRequestInterceptor,
+} from './posthog-request.interceptor';
+import { PostHogService } from './posthog.service';
+
+describe('PostHog request analytics', () => {
+  const request = {
+    headers: {
+      'x-posthog-distinct-id': 'mobile-user-1',
+      'x-posthog-session-id': 'session-1',
+    },
+    method: 'GET',
+    path: '/v1/members/42',
+    route: { path: '/v1/members/:id' },
+  };
+
+  it('extracts mobile correlation headers and a route template', () => {
+    expect(getPostHogRequestContext(request, 'tabt-rest')).toEqual({
+      distinctId: 'mobile-user-1',
+      properties: {
+        source: 'tabt-rest',
+        request_method: 'GET',
+        request_route: '/v1/members/:id',
+        $session_id: 'session-1',
+      },
+    });
+  });
+
+  it('uses one stable anonymous id and sanitizes fallback paths', () => {
+    expect(
+      getPostHogRequestContext(
+        { method: 'GET', path: '/v1/members/42' },
+        'tabt-rest',
+      ),
+    ).toEqual({
+      distinctId: 'tabt-rest:anonymous',
+      properties: {
+        source: 'tabt-rest',
+        request_method: 'GET',
+        request_route: '/v1/members/:id',
+      },
+    });
+  });
+
+  it('keeps error reporting safe when no HTTP request is available', () => {
+    expect(getPostHogRequestContext(undefined, 'app-notifications')).toEqual({
+      distinctId: 'app-notifications:anonymous',
+      properties: {
+        source: 'app-notifications',
+        request_method: undefined,
+        request_route: 'unknown',
+      },
+    });
+  });
+
+  it('captures a completed request with duration and status', async () => {
+    const posthog = { capture: jest.fn() };
+    const interceptor = new PostHogRequestInterceptor(
+      posthog as unknown as PostHogService,
+      'tabt-rest',
+    );
+    const context = httpContext(request, { statusCode: 200 });
+    const handler: CallHandler = { handle: () => of({ ok: true }) };
+
+    await lastValueFrom(interceptor.intercept(context, handler));
+
+    expect(posthog.capture).toHaveBeenCalledWith(
+      'api_request_completed',
+      'mobile-user-1',
+      expect.objectContaining({
+        source: 'tabt-rest',
+        request_route: '/v1/members/:id',
+        status_code: 200,
+        success: true,
+        duration_ms: expect.any(Number),
+      }),
+    );
+  });
+
+  it('captures failed requests with the exception status', async () => {
+    const posthog = { capture: jest.fn() };
+    const interceptor = new PostHogRequestInterceptor(
+      posthog as unknown as PostHogService,
+      'tabt-rest',
+    );
+    const context = httpContext(request, { statusCode: 200 });
+    const handler: CallHandler = {
+      handle: () => throwError(() => new HttpException('nope', 503)),
+    };
+
+    await expect(
+      lastValueFrom(interceptor.intercept(context, handler)),
+    ).rejects.toBeInstanceOf(HttpException);
+
+    expect(posthog.capture).toHaveBeenCalledWith(
+      'api_request_completed',
+      'mobile-user-1',
+      expect.objectContaining({ status_code: 503, success: false }),
+    );
+  });
+});
+
+function httpContext(request: object, response: object): ExecutionContext {
+  return {
+    getType: () => 'http',
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext;
+}

--- a/libs/common/src/posthog/posthog-request.interceptor.ts
+++ b/libs/common/src/posthog/posthog-request.interceptor.ts
@@ -1,0 +1,118 @@
+import { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { finalize, tap } from 'rxjs/operators';
+import { PostHogService } from './posthog.service';
+
+type HeaderValue = string | string[] | undefined;
+
+export interface PostHogHttpRequest {
+  headers?: Record<string, HeaderValue>;
+  method?: string;
+  path?: string;
+  url?: string;
+  baseUrl?: string;
+  route?: { path?: string };
+}
+
+export interface PostHogRequestContext {
+  distinctId: string;
+  properties: Record<string, unknown>;
+}
+
+function firstHeader(value: HeaderValue): string | undefined {
+  const header = Array.isArray(value) ? value[0] : value;
+  const trimmed = header?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function sanitizedPath(request: PostHogHttpRequest): string {
+  const routePath = request.route?.path;
+  if (routePath) return `${request.baseUrl ?? ''}${routePath}`;
+
+  return (request.path ?? request.url ?? 'unknown')
+    .split('?')[0]
+    .replace(
+      /\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?=\/|$)/gi,
+      '/:id',
+    )
+    .replace(/\/\d+(?=\/|$)/g, '/:id');
+}
+
+export function getPostHogRequestContext(
+  request: PostHogHttpRequest | undefined,
+  source: string,
+): PostHogRequestContext {
+  const safeRequest = request ?? {};
+  const distinctId =
+    firstHeader(safeRequest.headers?.['x-posthog-distinct-id']) ??
+    `${source}:anonymous`;
+  const sessionId = firstHeader(safeRequest.headers?.['x-posthog-session-id']);
+
+  return {
+    distinctId,
+    properties: {
+      source,
+      request_method: safeRequest.method,
+      request_route: sanitizedPath(safeRequest),
+      ...(sessionId ? { $session_id: sessionId } : {}),
+    },
+  };
+}
+
+function errorStatus(error: unknown): number | undefined {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'getStatus' in error &&
+    typeof error.getStatus === 'function'
+  ) {
+    const status = error.getStatus();
+    return typeof status === 'number' ? status : undefined;
+  }
+  return undefined;
+}
+
+/** Captures one low-cardinality event for each non-health HTTP request. */
+export class PostHogRequestInterceptor implements NestInterceptor {
+  constructor(
+    private readonly posthog: PostHogService,
+    private readonly source: string,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== 'http') return next.handle();
+
+    const http = context.switchToHttp();
+    const request = http.getRequest<PostHogHttpRequest>();
+    const response = http.getResponse<{ statusCode?: number }>();
+    const path = request.path ?? request.url ?? '';
+    if (path.startsWith('/health') || path.startsWith('/metrics')) {
+      return next.handle();
+    }
+
+    const startedAt = performance.now();
+    let failedStatus: number | undefined;
+
+    return next.handle().pipe(
+      tap({
+        error: (error: unknown) => {
+          failedStatus = errorStatus(error) ?? 500;
+        },
+      }),
+      finalize(() => {
+        const statusCode = failedStatus ?? response.statusCode ?? 200;
+        const requestContext = getPostHogRequestContext(request, this.source);
+        this.posthog.capture(
+          'api_request_completed',
+          requestContext.distinctId,
+          {
+            ...requestContext.properties,
+            status_code: statusCode,
+            success: statusCode < 400,
+            duration_ms: Math.round(performance.now() - startedAt),
+          },
+        );
+      }),
+    );
+  }
+}

--- a/libs/common/src/posthog/posthog.service.ts
+++ b/libs/common/src/posthog/posthog.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common';
 import { PostHog } from 'posthog-node';
 
-const DEFAULT_POSTHOG_HOST = 'https://eu.i.posthog.com';
+const DEFAULT_POSTHOG_HOST = 'https://t.beping.be';
 
 /**
- * Thin wrapper around the posthog-node client used for error tracking.
+ * Thin wrapper around the posthog-node client used for product analytics and
+ * error tracking.
  *
  * When POSTHOG_API_KEY is not configured the service stays a no-op: no client
  * is created and every method is safe to call, so local dev / CI / tests never
@@ -18,12 +19,38 @@ export class PostHogService implements OnApplicationShutdown {
   constructor() {
     const apiKey = process.env.POSTHOG_API_KEY;
     if (!apiKey) {
+      if (process.env.NODE_ENV === 'development') {
+        throw new Error(
+          'POSTHOG_API_KEY variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once POSTHOG_API_KEY is configured',
+        );
+      }
       this.client = null;
       return;
     }
     this.client = new PostHog(apiKey, {
       host: process.env.POSTHOG_HOST || DEFAULT_POSTHOG_HOST,
     });
+  }
+
+  /** Capture a backend product event without creating person profiles. */
+  capture(
+    event: string,
+    distinctId: string,
+    properties?: Record<string | number, unknown>,
+  ): void {
+    if (!this.client) return;
+    try {
+      this.client.capture({
+        event,
+        distinctId,
+        properties: {
+          $process_person_profile: false,
+          ...properties,
+        },
+      });
+    } catch (err) {
+      this.logger.warn(`Failed to capture PostHog event: ${err}`);
+    }
   }
 
   /**
@@ -39,7 +66,15 @@ export class PostHogService implements OnApplicationShutdown {
       return;
     }
     try {
-      this.client.captureException(error, distinctId, extraProps);
+      const source = String(extraProps?.source ?? 'backend');
+      this.client.captureException(
+        error,
+        distinctId?.trim() || `${source}:anonymous`,
+        {
+          $process_person_profile: false,
+          ...extraProps,
+        },
+      );
     } catch (err) {
       this.logger.warn(`Failed to report exception to PostHog: ${err}`);
     }


### PR DESCRIPTION
## Résumé

- capture les requêtes API et notifications dans PostHog sans créer de profils
- enrichit le suivi des exceptions et des imports
- documente la configuration PostHog partagée des services BePing

## Motivation

Centraliser l’observabilité backend de l’API, des notifications et de l’importeur dans le projet BePing Backend.

## Validation

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec jest --runInBand` (66 suites, 326 tests)
- builds Nest des trois applications

Le commit utilise `[skip ci]` pour éviter les minutes GitHub-hosted; les images de production sont construites localement pour ARM64 puis promues via le runner privé.